### PR TITLE
 Display number of likes for each item on the Homepage 

### DIFF
--- a/src/modules/displayMovies.js
+++ b/src/modules/displayMovies.js
@@ -1,3 +1,5 @@
+import { getLikesCount } from './likesCount';
+
 const moviesURL = 'https://api.tvmaze.com/shows';
 const movieTemplate = document.getElementById('movie-template');
 const movieSection = document.querySelector('.movieSection');
@@ -13,8 +15,20 @@ const getAllMovies = async () => {
     movieImage.height = 250;
     const movieTitle = movieElement.querySelector('.movieTitle');
     movieTitle.innerHTML = movie.name;
+    const movieLikes = movieElement.querySelector('.likeNo');
+    movieLikes.setAttribute('id', `${movie.id}`);
     movieSection.appendChild(movieElement);
   });
+
+  const updateLikesCount = async () => {
+    const likesData = await getLikesCount();
+    likesData.forEach((item) => {
+      const likesCount = item.likes;
+      const likesCountElement = document.getElementById(`${item.item_id}`);
+      likesCountElement.innerHTML = likesCount;
+    });
+  };
+  updateLikesCount();
 };
 
 export default getAllMovies;

--- a/src/modules/displayMovies.js
+++ b/src/modules/displayMovies.js
@@ -1,4 +1,4 @@
-import { getLikesCount } from './likesCount';
+import { getLikesCount } from './likesCount.js';
 
 const moviesURL = 'https://api.tvmaze.com/shows';
 const movieTemplate = document.getElementById('movie-template');

--- a/src/modules/likesCount.js
+++ b/src/modules/likesCount.js
@@ -1,5 +1,4 @@
-const likesApi =
-  'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/UKP27MmenkdUVvm9H93H/likes';
+const likesApi = 'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/UKP27MmenkdUVvm9H93H/likes';
 
 const postLikes = async (id) => {
   const test = { item_id: id };

--- a/src/modules/likesCount.js
+++ b/src/modules/likesCount.js
@@ -1,0 +1,21 @@
+const likesApi =
+  'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/UKP27MmenkdUVvm9H93H/likes';
+
+const postLikes = async (id) => {
+  const test = { item_id: id };
+  await fetch(likesApi, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(test),
+  });
+};
+
+const getLikesCount = async () => {
+  const likes = await fetch(likesApi);
+  const response = await likes.json();
+  return response;
+};
+
+export { postLikes, getLikesCount };


### PR DESCRIPTION
When the page loads, the webapp the [Involvement API](https://www.notion.so/microverse/Involvement-API-869e60b5ad104603aa6db59e08150270) to show the item likes and combines them with the data from the base API.